### PR TITLE
BOAF-1003 add the patch for not to cache nested schemas which is being used in rails and erp sync

### DIFF
--- a/lib/avro_turf/schema_store.rb
+++ b/lib/avro_turf/schema_store.rb
@@ -49,8 +49,8 @@ class AvroTurf::SchemaStore
   def load_schema!(fullname, namespace = nil)
     *namespace, schema_name = fullname.split(".")
     schema_path = File.join(@path, *namespace, schema_name + ".avsc")
-    schema_json = JSON.parse(File.read(schema_path))
-    schema = Avro::Schema.real_parse(schema_json, @schemas)
+    schema = Avro::Schema.parse(File.read(schema_path))
+    @schemas[fullname] = schema
 
     if schema.respond_to?(:fullname) && schema.fullname != fullname
       raise AvroTurf::SchemaError, "expected schema `#{schema_path}' to define type `#{fullname}'"


### PR DESCRIPTION
Currently rails-site and erp-sync workers are using this patch. so merging the master changes from upstream and adding this patch so the master branch of this repository can be used rails-site and erp-sync workers

https://github.com/dollarshaveclub/avro_turf/commit/c670242194022489900442e99a256644743189cd